### PR TITLE
fix: no-name-global-components

### DIFF
--- a/umono-lang.go
+++ b/umono-lang.go
@@ -47,6 +47,10 @@ func (ul *UmonoLang) Convert(raw string) string {
 
 func (ul *UmonoLang) ConvertGlobalComp(compName, raw string) string {
 
+	if compName == "" {
+		return ul.Convert(raw)
+	}
+
 	content := raw
 	localComps := []interfaces.Component{}
 


### PR DESCRIPTION
The ConvertGlobalComp function doesn't need to convert if the compName is empty.